### PR TITLE
Add additional default ignored routes

### DIFF
--- a/config/pretty-routes.php
+++ b/config/pretty-routes.php
@@ -48,7 +48,9 @@ return [
      */
 
     'hide_matching' => [
+        '#^__clockwork#',
         '#^_debugbar#',
+        '#^horizon#',
         '#^_ignition#',
         '#^telescope#',
         '#^routes#',


### PR DESCRIPTION
Ignores routes from https://laravel.com/docs/8.x/horizon and https://underground.works/clockwork/